### PR TITLE
Update table size styling for responsive screen

### DIFF
--- a/app/src/app/home/home.component.html
+++ b/app/src/app/home/home.component.html
@@ -1,10 +1,10 @@
 <div class="container">
-  <img src="assets/slippi-logo.png" class="slippi-main-logo" (click)="slippiService.isLoading = !slippiService.isLoading" style="height: 100px; width: 100px;">
-
   <div class="loader" [hidden]="!isLoading"></div>
 
   <div class="table-container" [ngClass]="{ 'display-none' : isLoading }">
     <div class="filter-section date-picker">
+      <img src="assets/slippi-logo.png" class="slippi-main-logo">
+
       <div class="filter">
         <div class="filter-header">
           {{ 'Date' }}

--- a/app/src/styles.scss
+++ b/app/src/styles.scss
@@ -1,6 +1,7 @@
 @import "../node_modules/@angular/material/prebuilt-themes/indigo-pink.css";
 $slippi-green: #00bb77;
 $slippi-green-dark: #004d30;
+$container-padding: 4px;
 
 html, body {
   margin: 0;
@@ -24,9 +25,9 @@ html, body {
 .table-container {
   display: flex;
   flex-direction: row;
-  min-width: 800px;
-  min-height: 600px;
-  padding: 4px;
+  width: 90%;
+  height: 90vh;
+  padding: $container-padding;
   border: 2px double #666;
   background-color: $slippi-green;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120' viewBox='0 0 120 120'%3E%3Cpolygon fill='%23000' fill-opacity='.1' points='120 0 120 60 90 30 60 0 0 0 0 0 60 60 0 120 60 120 90 90 120 60 120 0'/%3E%3C/svg%3E");
@@ -35,6 +36,7 @@ html, body {
     display: flex;
     flex-direction: column;
     position: relative;
+    width: 85%;
   }
 
   .stock-img {
@@ -69,10 +71,15 @@ html, body {
   }
 
   .filter-section {
-    max-width: 200px;
+    width: 15%;
     padding: 5px;
     background-color: $slippi-green;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400' viewBox='0 0 200 200'%3E%3Cg fill='none' stroke='%237F3' stroke-width='1' stroke-opacity='0.2'%3E%3Crect x='-40' y='40' width='75' height='75'/%3E%3Crect x='-35' y='45' width='65' height='65'/%3E%3Crect x='-30' y='50' width='55' height='55'/%3E%3Crect x='-25' y='55' width='45' height='45'/%3E%3Crect x='-20' y='60' width='35' height='35'/%3E%3Crect x='-15' y='65' width='25' height='25'/%3E%3Crect x='-10' y='70' width='15' height='15'/%3E%3Crect x='-5' y='75' width='5' height='5'/%3E%3Crect width='35' height='35'/%3E%3Crect x='5' y='5' width='25' height='25'/%3E%3Crect x='10' y='10' width='15' height='15'/%3E%3Crect x='15' y='15' width='5' height='5'/%3E%3Crect x='40' width='75' height='75'/%3E%3Crect x='45' y='5' width='65' height='65'/%3E%3Crect x='50' y='10' width='55' height='55'/%3E%3Crect x='55' y='15' width='45' height='45'/%3E%3Crect x='60' y='20' width='35' height='35'/%3E%3Crect x='65' y='25' width='25' height='25'/%3E%3Crect x='70' y='30' width='15' height='15'/%3E%3Crect x='75' y='35' width='5' height='5'/%3E%3Crect x='40' y='80' width='35' height='35'/%3E%3Crect x='45' y='85' width='25' height='25'/%3E%3Crect x='50' y='90' width='15' height='15'/%3E%3Crect x='55' y='95' width='5' height='5'/%3E%3Crect x='120' y='-40' width='75' height='75'/%3E%3Crect x='125' y='-35' width='65' height='65'/%3E%3Crect x='130' y='-30' width='55' height='55'/%3E%3Crect x='135' y='-25' width='45' height='45'/%3E%3Crect x='140' y='-20' width='35' height='35'/%3E%3Crect x='145' y='-15' width='25' height='25'/%3E%3Crect x='150' y='-10' width='15' height='15'/%3E%3Crect x='155' y='-5' width='5' height='5'/%3E%3Crect x='120' y='40' width='35' height='35'/%3E%3Crect x='125' y='45' width='25' height='25'/%3E%3Crect x='130' y='50' width='15' height='15'/%3E%3Crect x='135' y='55' width='5' height='5'/%3E%3Crect y='120' width='75' height='75'/%3E%3Crect x='5' y='125' width='65' height='65'/%3E%3Crect x='10' y='130' width='55' height='55'/%3E%3Crect x='15' y='135' width='45' height='45'/%3E%3Crect x='20' y='140' width='35' height='35'/%3E%3Crect x='25' y='145' width='25' height='25'/%3E%3Crect x='30' y='150' width='15' height='15'/%3E%3Crect x='35' y='155' width='5' height='5'/%3E%3Crect x='200' y='120' width='75' height='75'/%3E%3Crect x='40' y='200' width='75' height='75'/%3E%3Crect x='80' y='80' width='75' height='75'/%3E%3Crect x='85' y='85' width='65' height='65'/%3E%3Crect x='90' y='90' width='55' height='55'/%3E%3Crect x='95' y='95' width='45' height='45'/%3E%3Crect x='100' y='100' width='35' height='35'/%3E%3Crect x='105' y='105' width='25' height='25'/%3E%3Crect x='110' y='110' width='15' height='15'/%3E%3Crect x='115' y='115' width='5' height='5'/%3E%3Crect x='80' y='160' width='35' height='35'/%3E%3Crect x='85' y='165' width='25' height='25'/%3E%3Crect x='90' y='170' width='15' height='15'/%3E%3Crect x='95' y='175' width='5' height='5'/%3E%3Crect x='120' y='160' width='75' height='75'/%3E%3Crect x='125' y='165' width='65' height='65'/%3E%3Crect x='130' y='170' width='55' height='55'/%3E%3Crect x='135' y='175' width='45' height='45'/%3E%3Crect x='140' y='180' width='35' height='35'/%3E%3Crect x='145' y='185' width='25' height='25'/%3E%3Crect x='150' y='190' width='15' height='15'/%3E%3Crect x='155' y='195' width='5' height='5'/%3E%3Crect x='160' y='40' width='75' height='75'/%3E%3Crect x='165' y='45' width='65' height='65'/%3E%3Crect x='170' y='50' width='55' height='55'/%3E%3Crect x='175' y='55' width='45' height='45'/%3E%3Crect x='180' y='60' width='35' height='35'/%3E%3Crect x='185' y='65' width='25' height='25'/%3E%3Crect x='190' y='70' width='15' height='15'/%3E%3Crect x='195' y='75' width='5' height='5'/%3E%3Crect x='160' y='120' width='35' height='35'/%3E%3Crect x='165' y='125' width='25' height='25'/%3E%3Crect x='170' y='130' width='15' height='15'/%3E%3Crect x='175' y='135' width='5' height='5'/%3E%3Crect x='200' y='200' width='35' height='35'/%3E%3Crect x='200' width='35' height='35'/%3E%3Crect y='200' width='35' height='35'/%3E%3C/g%3E%3C/svg%3E");
+
+    .slippi-main-logo {
+      width: 40%;
+      margin-bottom: 15px;
+    }
 
     .mat-form-field-infix {
       margin-top: -15px;
@@ -119,8 +126,8 @@ html, body {
   position: absolute;
   left: 0;
   bottom: 0;
-  width: 100%;
   text-align: center;
+  width: calc(100% - #{$container-padding} / 2);
 }
 
 ::ng-deep .mat-select-panel {
@@ -138,8 +145,6 @@ html, body {
 
 .mat-table {
   overflow: auto;
-  max-height: 600px;
-  min-width: 610px;
 
   .mat-cell {
     position: relative;
@@ -156,12 +161,6 @@ html, body {
 .mat-sort-header {
   color: white;
   font-weight: bold;
-}
-
-.slippi-main-logo {
-  position: absolute;
-  top: 0;
-  left: 0;
 }
 
 .loader {


### PR DESCRIPTION
Make table width 90% of the screen width and heighth wise.
Make filters 15% of the container and table 85% of the container.
Move the slippi logo at the top of the filter section. I'm not sure exactly why this is here besides the fact that it looks nice. It could server some function later maybe.