### PR TITLE
Add typeahead/autocomplete to player filter

### DIFF
--- a/app/src/app/home/home.component.html
+++ b/app/src/app/home/home.component.html
@@ -21,7 +21,12 @@
           {{ 'Players' }}
         </div>
         <mat-form-field>
-          <input matInput #players type="text" [(ngModel)]="filters.players">
+          <input matInput #players type="text" [(ngModel)]="filters.players" [matAutocomplete]="playerAuto">
+          <mat-autocomplete autoActiveFirstOption #playerAuto="matAutocomplete" (optionSelected)="onPlayerSelected($event)">
+            <mat-option *ngFor="let option of allPlayerNames" [value]="option">
+              {{option}}
+            </mat-option>
+          </mat-autocomplete>
         </mat-form-field>
       </div>
 

--- a/app/src/app/home/home.component.ts
+++ b/app/src/app/home/home.component.ts
@@ -33,7 +33,8 @@ export class HomeComponent implements OnInit {
   data: SlippiRow[] = [];
   dataSource: MatTableDataSource<SlippiRow>;
   activeDates: number[];
-  displayedColumns= ["startAt", "playerOneName", "playerTwoName"];
+  displayedColumns= ['startAt', 'playerOneName', 'playerTwoName'];
+  allPlayerNames = ['elliot', 'ben', 'alex'];
 
   // properties for loading winning player.
   currentlyLoadingSlippiRows: SlippiRow[];
@@ -52,6 +53,7 @@ export class HomeComponent implements OnInit {
           this.dataSource.paginator = this.paginator;
           this.dataSource.sort = this.sort;
 
+          this.getAllPlayerNames();
           this.getActiveDates();
           this.isLoading = false;
           setTimeout(_ => {
@@ -72,7 +74,7 @@ export class HomeComponent implements OnInit {
   applyFilter() {
     const filter = this.filters;
     const startAt = (e: SlippiRow) => filter.startAt == null || moment(e.startAt).startOf('day').diff(moment(filter.startAt).startOf('day'), 'days') === 0;
-    const players = (e: SlippiRow) => !filter.players || `${e.playerOneName}`.toLowerCase().includes(filter.players.toLowerCase()) || `${e.playerTwoName}`.toLowerCase().includes(filter.players.toLowerCase());
+    const players = (e: SlippiRow) => !filter.players || `${e.playerOneName}`.toLowerCase().includes(filter.players.trim().toLowerCase()) || `${e.playerTwoName}`.toLowerCase().includes(filter.players.trim().toLowerCase());
     const filters = R.allPass([startAt, players])
 
     this.dataSource.data = this.data.filter(d => filters(d));
@@ -92,6 +94,12 @@ export class HomeComponent implements OnInit {
         }
       });
     }, 50);
+  }
+
+  onPlayerSelected(event: any) {
+    console.log(event);
+    console.log(this.filters);
+    this.applyFilter();
   }
 
   private sortMetadata(a: SlippiRaw, b: SlippiRaw): number {
@@ -179,7 +187,22 @@ export class HomeComponent implements OnInit {
     }
   }
 
+  private getAllPlayerNames() {
+    if (this.dataSource.data) {
+      this.allPlayerNames =
+        this.dataSource.data.map(d => d.playerOneName)
+          .concat(this.dataSource.data.map(d => d.playerTwoName))
+          .filter(this.distinctStrings)
+          .filter(s => s !== '')
+          .sort();
+    }
+  }
+
   private distinctDates(dateValue: number, index: number, self: number[]) {
     return self.findIndex(d => d === dateValue) === index;
+  }
+
+  private distinctStrings(stringValue: string, index: number, self: string[]) {
+    return self.findIndex(d => d === stringValue) === index;
   }
 }

--- a/app/src/app/home/home.module.ts
+++ b/app/src/app/home/home.module.ts
@@ -7,6 +7,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 
 import { HomeRoutingModule } from './home-routing.module';
 
@@ -26,7 +27,8 @@ import { SlippiService } from 'app/shared/services/slippi.service';
     MatFormFieldModule,
     MatInputModule,
     MatDatepickerModule,
-    MatNativeDateModule
+    MatNativeDateModule,
+    MatAutocompleteModule
   ]
 })
 export class HomeModule {}


### PR DESCRIPTION
Add MatAutocompleteModule to home.module.
Add mat-autocomplete directive in mat-form-field for players filter.
Get all player names for autocomplete in home-component.
Trim player name filter on apply filter.